### PR TITLE
Add evanhahn.com

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -8,6 +8,11 @@
   method: unknown
   last_checked: 2022-07-16
 
+- domain: evanhahn.com
+  url: https://evanhahn.com/
+  method: mediaquery
+  last_checked: 2022-07-16
+
 - domain: garrit.xyz
   url: https://garrit.xyz/
   method: mediaquery


### PR DESCRIPTION
This adds my site, <https://evanhahn.com>, to the list, which [uses][0] the media query method.

[0]: https://github.com/EvanHahn/evanhahn-dot-com/blob/919fb1ca2839400ce245be5ca82daee5a541fab6/assets/sass/variables.scss#L16-L25

---

This PR is:

- [x] Adding a new domain

<!--
*Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] The domain is in the correct alphabetical order
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://darktheme.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm