### PR TITLE
Adds hugo.md

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -27,6 +27,11 @@
   url: https://github.com/
   method: mediaquery
   last_checked: 2022-07-16
+
+- domain: hugo.md
+  url: https://hugo.md/
+  method: mediaquery
+  last_checked: 2022-07-17
   
 - domain: jlelse.blog
   url: https://jlelse.blog/


### PR DESCRIPTION
Neat club! I'm a big fan of websites that support light/dark modes.

This change adds my [personal blog](https://hugo.md).

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (darktheme.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] The domain is in the correct alphabetical order
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://darktheme.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

<!-- Sample
```
- domain: example.com
  url: http://example.com/ (Make sure you keep the trailing slash)
  method: mediaquery (Choose one of "mediaquery", "javascript", "darkonly", "opt-in", "unknown")
  last_checked: 2022-06-02 (YYYY-MM-DD)
```
-->
```
- domain: hugo.md
  url: https://hugo.md
  method: mediaquery
  last_checked: 2022-07-17
```