### PR TITLE
add codeberg.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -23,6 +23,11 @@
   method: darkonly
   last_checked: 2022-07-17
   
+- domain: codeberg.org
+  url: https://codeberg.org/
+  method: mediaquery
+  last_checked: 2022-07-21
+  
 - domain: duckduckgo.com
   url: https://duckduckgo.com/
   method: unknown


### PR DESCRIPTION
Default theme uses media query. Logged-in users can choose alternative themes which default to light or dark.

<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

This PR is:

- [x] Adding a new domain
- [ ] Updating existing domain
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (darktheme.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] The domain is in the correct alphabetical order
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ section](https://darktheme.club/faq), particularly the two red items around minimal pages and inappropriate content and I attest that this site is neither of these things.***

- [x] Check to confirm

<!-- Sample
```
- domain: example.com
  url: http://example.com/ (Make sure you keep the trailing slash)
  method: mediaquery (Choose one of "mediaquery", "javascript", "darkonly", "opt-in", "unknown")
  last_checked: 2022-06-02 (YYYY-MM-DD)
```
-->
```
- domain: codeberg.org
  url: https://codeberg.org/
  method: mediaquery
  last_checked: 2022-07-21
```