### PR TITLE
Added two dark theme domains:  castorisdead.xyz and whoisyoges.eu.org

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -27,6 +27,11 @@
   url: https://bubble.email
   method: darkonly
   last_checked: 2022-07-17
+
+- domain: castorisdead.xyz
+  url: https://castorisdead.xyz
+  method: darkonly
+  last_checked: 2022-21-12
   
 - domain: codeberg.org
   url: https://codeberg.org/

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -177,3 +177,8 @@
   url: https://watch3r.app/
   method: darkonly
   last_checked: 2022-07-20
+
+- domain: whoisyoges.eu.org
+  url: https://whoisyoges.eu.org/
+  method: darkonly
+  last_checked: 2022-12-12


### PR DESCRIPTION
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

Websites: <https://castorisdead.xyz/> and <https://whoisyoges.eu.org/>

This PR is:

- [x] Adding new domains
- [ ] Updating existing domain
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (darktheme.club site)
- [ ] Other not listed

- [x] The domains are in the correct alphabetical order
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ page](https://darktheme.club/faq), particularly the red section about inappropriate content, and I attest that this site is appropriate based on those criteria.***

- [x] Check to confirm


```
- domain: castorisdead.xyz
  url: https://castorisdead.xyz/
  method: darkonly
  last_checked: 2022-12-12
```

```
- domain: whoisyoges.eu.org
  url: https://whoisyoges.eu.org/
  method: darkonly
  last_checked: 2022-12-12
```