### PR TITLE
update til.pm with proper method used

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -210,8 +210,8 @@
  
 - domain: til.pm
   url: https://til.pm
-  method: mediaquery
-  last_checked: 2023-02-19
+  method: javascript
+  last_checked: 2023-02-24
   
 - domain: traeblain.com
   url: https://traeblain.com/


### PR DESCRIPTION
since site requires javascript (and also literally does determine defaults using js) i might as well fix it

Website (if applicable): https://til.pm

This PR is:

- [ ] Adding a new domain
- [x] Updating existing domain
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (darktheme.club site)
- [ ] Other not listed

- [x] The domain is in the correct alphabetical order
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ page](https://darktheme.club/faq), particularly the red section about inappropriate content, and I attest that this site is appropriate based on those criteria.***

- [x] Check to confirm
