### PR TITLE
Add Can I Stop, Can We, Burokku

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -53,6 +53,11 @@
   method: mediaquery
   last_checked: 2022-04-16
 
+- domain: block.sunappu.net
+  url: https://block.sunappu.net
+  method: mediaquery
+  last_checked: 2023-08-30
+  
 - domain: blog.darylsun.page
   url: https://blog.darylsun.page/
   method: mediaquery
@@ -72,6 +77,16 @@
   url: https://castorisdead.xyz
   method: darkonly
   last_checked: 2022-12-21
+
+- domain: canistop.net
+  url: https://canistop.net
+  method: mediaquery
+  last_checked: 2023-08-30
+
+- domain: canwe.dev
+  url: https://canwe.dev
+  method: mediaquery
+  last_checked: 2023-08-30
 
 - domain: chino.is-a.dev
   url: https://chino.is-a.dev/


### PR DESCRIPTION
This PR is:

- [x] Adding a new domain
- [x] Adding a new domain
- [x] Adding a new domain

(Yes, it adds 3 domains.)

- [x] The domain is in the correct alphabetical order
- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ page](https://darktheme.club/faq), particularly the red section about inappropriate content, and I attest that this site is appropriate based on those criteria.***

- [x] Check to confirm

> **Note**
> For `canistop.net`, it honors `prefers-color-scheme` while also allowing to override it using JavaScript. In that scenario, I guess it’s probably better to leave “mediaquery” as method, but not sure. Please tell me if it’s wrong!