### PR TITLE
Update sites.yml: +Gwern.net

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -187,6 +187,11 @@
   url: https://github.com/
   method: mediaquery
   last_checked: 2022-07-16
+
+- domain: gwern.net
+  url: https://gwern.net
+  method: mediaquery
+  last_checked: 2023-11-02
   
 - domain: hen.ee
   url: https://hen.ee/


### PR DESCRIPTION
Gwern.net uses a custom dark-mode which respects media-query but uses JS to provide a three-state toggle: 'auto', 'dark', and 'light'.

Dark-mode fully supports all site features, including dropcaps (in the case of custom dropcap sets like the 'dropcats', they come in both dark & light-specific editions).

Demo screenshots:

- https://gwern.net/doc/cs/css/2023-08-21-gwern-gwernnet-desktop-index-darkmode-pagetopwithtoggleopen.png
- https://gwern.net/doc/cs/css/2023-08-21-gwern-gwernnet-desktop-index-darkmode-pagetopwithtoggleopen.png
- https://gwern.net/doc/newsletter/2021-03-28-gwern-gwernnet-annotations-mobilepopins-darkmode.png

Website (if applicable): https://gwern.net 
This PR is:

- [ ✓] Adding a new domain
- [ ✓] The domain is in the correct alphabetical order
- [ ✓] The following information is filled identical to the data file

***I confirm that I have read the [FAQ page](https://darktheme.club/faq), particularly the red section about inappropriate content, and I attest that this site is appropriate based on those criteria.***

- [✓ ] Check to confirm
