### PR TITLE
Replaced sebastinux.com by sebastien-mouchet.fr

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -373,10 +373,10 @@
   method: darkonly
   last_checked: 2023-06-17
 
-- domain: sebastinux.com
-  url: https://sebastinux.com/
+- domain: sebastien-mouchet.fr
+  url: https://sebastien-mouchet.fr/
   method: mediaquery
-  last_checked: 2023-05-31
+  last_checked: 2023-12-14
 
 - domain: seeking-maintainers.net
   url: https://seeking-maintainers.net/


### PR DESCRIPTION
I moved my blog from sebastinux.com to sebastien-mouchet.fr

Website (if applicable): https://sebastien-mouchet.fr

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain
- [x] Changing domain name
- [ ] Removing existing domain from list
- [ ] Website code changes (darktheme.club site)
- [ ] Other not listed

- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ page](https://darktheme.club/faq), particularly the red section about inappropriate content, and I attest that this site is appropriate based on those criteria.***

- [x] Check to confirm

```
- domain: sebastien-mouchet.fr
  url: https://sebastien-mouchet.fr/
  method: mediaquery
  last_checked: 2023-12-14
```
