### PR TITLE
Add CSS `color-scheme` property as a method option

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.yml
+++ b/.github/PULL_REQUEST_TEMPLATE.yml
@@ -29,7 +29,7 @@ This PR is:
 ```
 - domain: example.com
   url: http://example.com/ (Make sure you keep the trailing slash)
-  method: mediaquery (Choose one of "mediaquery", "javascript", "darkonly", "opt-in", "unknown")
+  method: mediaquery (Choose one of "colorscheme", "mediaquery", "javascript", "darkonly", "opt-in", "unknown")
   last_checked: 2022-06-02 (YYYY-MM-DD)
 ```
 -->

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the readers sight at night.
 **The Darktheme Club** is a collection of web pages from across the Internet. To
 qualify, your website must either offer a dark theme by default, or respect the
 preference of the user, preferably through the
-[prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+[color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) CSS property or the [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
 media query.
 
 ## How to create a PR to add your site to the Darktheme Club
@@ -25,7 +25,7 @@ It's simple!
 ```
 - domain: example.com
   url: http://example.com/ (Make sure you keep the trailing slash)
-  method: mediaquery (Choose one of "mediaquery", "javascript", "darkonly", "opt-in", "unknown")
+  method: mediaquery (Choose one of "colorscheme", "mediaquery", "javascript", "darkonly", "opt-in", "unknown")
   last_checked: 2022-06-02 (YYYY-MM-DD)
 ```
 #### Blank

--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -275,8 +275,13 @@
 
 - domain: helenchong.dev
   url: https://helenchong.dev/
-  method: mediaquery
-  last_checked: 2024-07-13
+  method: colorscheme
+  last_checked: 2024-11-19
+
+- domain: blog.helenchong.omg.lol
+  url: https://blog.helenchong.omg.lol/
+  method: colorscheme
+  last_checked: 2024-11-19
 
 - domain: hen.ee
   url: https://hen.ee/

--- a/_includes/sites.html
+++ b/_includes/sites.html
@@ -2,7 +2,7 @@
 
 {% if methods == 'colorscheme' %}
   {% assign method = "ColorScheme" %}
-{% if methods == 'mediaquery' %}
+{% elsif methods == 'mediaquery' %}
   {% assign method = "MediaQuery" %}
 {% elsif methods == 'javascript' %}
   {% assign method = "JavaScript" %}

--- a/_includes/sites.html
+++ b/_includes/sites.html
@@ -1,5 +1,7 @@
 {% capture methods %}{{ item.method }}{% endcapture %}
 
+{% if methods == 'colorscheme' %}
+  {% assign method = "ColorScheme" %}
 {% if methods == 'mediaquery' %}
   {% assign method = "MediaQuery" %}
 {% elsif methods == 'javascript' %}

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ the readers sight at night.
 **The Darktheme Club** is a collection of web pages from across the Internet. To
 qualify, your website must either use a dark theme by default, or respect the
 preference of the user, preferably through the
-[prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+[color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) CSS property or the [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
 media query.
 
 <br>


### PR DESCRIPTION
Per https://github.com/garritfra/darktheme.club/issues/194, I am adding the CSS [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) property as an option for the "method" field in website submissions, by adding the option to the pull request template and adding the MDN link to `color-scheme` to the darktheme.club website and its README.

I am also updating my helenchong.dev domain and add my blog.helenchong.omg.lol domain as examples of the `color-scheme` method.

---
<!--
**Important:** Please read all instructions carefully.

_Select the appropriate category for what this PR is about_
-->

Website (if applicable): https://helenchong.dev, https://blog.helenchong.omg.lol

This PR is:

- [x] Adding a new domain
- [x] Updating existing domain
- [ ] Changing domain name
- [ ] Removing existing domain from list
- [x] Website code changes (darktheme.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.
-->

- [x] The following information is filled identical to the data file

***I confirm that I have read the [FAQ page](https://darktheme.club/faq), particularly the red section about inappropriate content, and I attest that this site is appropriate based on those criteria.***

- [x] Check to confirm

<!-- Sample
```
- domain: example.com
  url: http://example.com/ (Make sure you keep the trailing slash)
  method: mediaquery (Choose one of "mediaquery", "javascript", "darkonly", "opt-in", "unknown")
  last_checked: 2022-06-02 (YYYY-MM-DD)
```
-->
```
- domain: helenchong.dev
  url: https://helenchong.dev/
  method: colorscheme
  last_checked: 2024-11-19
```

```
- domain: blog.helenchong.omg.lol
  url: https://blog.helenchong.omg.lol/
  method: colorscheme
  last_checked: 2024-11-19
```
