### PR TITLE
sites.yml: remove blog.leenucks.xyz

### DIFF
--- a/_data/sites.yml
+++ b/_data/sites.yml
@@ -83,11 +83,6 @@
   method: colorscheme
   last_checked: 2024-11-19
 
-- domain: blog.leenucks.xyz
-  url: https://blog.leenucks.xyz/
-  method: darkonly
-  last_checked: 2024-11-14
-
 - domain: blog.madelinepritchard.net
   url: https://blog.madelinepritchard.net/
   method: mediaquery


### PR DESCRIPTION
My website no longer uses dark mode.

Website (if applicable): https://blog.leenucks.xyz

This PR is:

- [ ] Adding a new domain
- [ ] Updating existing domain
- [ ] Changing domain name
- [X] Removing existing domain from list
- [ ] Website code changes (darktheme.club site)
- [ ] Other not listed

<!--
*Do not tick a checkbox if you haven't performed its action.* Honesty is indispensable for a smooth review process.
-->

- [X] The following information is filled identical to the data file

***I confirm that I have read the [FAQ page](https://darktheme.club/faq), particularly the red section about inappropriate content, and I attest that this site is appropriate based on those criteria.***

- [X] Check to confirm